### PR TITLE
IntelliJ out directory added to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@
 /.classpath.idea/
 DbSetup.iml
 .idea
+out
 classes


### PR DESCRIPTION
I have imported the DbSetup gradle project into IntelliJ IDEA wich configures by default the output path for compilation results to the out directory.
