### PR TITLE
Add static builder in destination implementations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@
 /.classpath.idea/
 DbSetup.iml
 .idea
+out
 classes

--- a/src/main/java/com/ninja_squad/dbsetup/destination/DataSourceDestination.java
+++ b/src/main/java/com/ninja_squad/dbsetup/destination/DataSourceDestination.java
@@ -41,6 +41,10 @@ import com.ninja_squad.dbsetup.util.Preconditions;
 public final class DataSourceDestination implements Destination {
     private final DataSource dataSource;
 
+    public static DataSourceDestination to(@Nonnull DataSource dataSource) {
+        return new DataSourceDestination(dataSource);
+    }
+
     /**
      * Constructor
      * @param dataSource the wrapped DataSource

--- a/src/main/java/com/ninja_squad/dbsetup/destination/DriverManagerDestination.java
+++ b/src/main/java/com/ninja_squad/dbsetup/destination/DriverManagerDestination.java
@@ -44,6 +44,10 @@ public final class DriverManagerDestination implements Destination {
     private final String user;
     private final String password;
 
+    public static DriverManagerDestination to(@Nonnull String url, String user, String password) {
+        return new DriverManagerDestination(url, user, password);
+    }
+
     /**
      * Constructor
      * @param url the URL of the database


### PR DESCRIPTION
It would be nice to have builder methods on destinations. 

I find the first way to initialize DbSetup nicer than the second one :

``` java
  DbSetup dbSetup = new DbSetup(to(dataSource), operation);
```

``` java
  DbSetup dbSetup = new DbSetup(new DataSourceDestination(dataSource), operation);
```
