### PR TITLE
Add static builder in destination implementations

### DIFF
--- a/src/main/java/com/ninja_squad/dbsetup/destination/DataSourceDestination.java
+++ b/src/main/java/com/ninja_squad/dbsetup/destination/DataSourceDestination.java
@@ -41,7 +41,7 @@ import com.ninja_squad.dbsetup.util.Preconditions;
 public final class DataSourceDestination implements Destination {
     private final DataSource dataSource;
 
-    public static DataSourceDestination to(@Nonnull DataSource dataSource) {
+    public static DataSourceDestination with(@Nonnull DataSource dataSource) {
         return new DataSourceDestination(dataSource);
     }
 

--- a/src/main/java/com/ninja_squad/dbsetup/destination/DriverManagerDestination.java
+++ b/src/main/java/com/ninja_squad/dbsetup/destination/DriverManagerDestination.java
@@ -44,7 +44,7 @@ public final class DriverManagerDestination implements Destination {
     private final String user;
     private final String password;
 
-    public static DriverManagerDestination to(@Nonnull String url, String user, String password) {
+    public static DriverManagerDestination with(@Nonnull String url, String user, String password) {
         return new DriverManagerDestination(url, user, password);
     }
 


### PR DESCRIPTION
It would be nice to have builder methods on destinations. 

I find the first way to initialize DbSetup (with static import) nicer than the second one :

``` java
  DbSetup dbSetup = new DbSetup(to(dataSource), operation);
```

``` java
  DbSetup dbSetup = new DbSetup(new DataSourceDestination(dataSource), operation);
```
