### PR TITLE
added a ConnectionDestination for direct usage of the type java.sql.Connection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ configurations {
 
 task checkJavaVersion << {
     if (!JavaVersion.current().isJava6Compatible()) {
-        String message = "ERROR: Java 1.6 required but " +
+        String message = "ERROR: Java 1.6 compatilbe JRE is required but " +
                          JavaVersion.current() +
                          " found. Change your JAVA_HOME environment variable.";
         throw new IllegalStateException(message);

--- a/build.gradle
+++ b/build.gradle
@@ -47,9 +47,9 @@ configurations {
 }
 
 task checkJavaVersion << {
-    if (!JavaVersion.current().isJava6()) {
-        String message = "ERROR: Java 1.6 required but " + 
-                         JavaVersion.current() + 
+    if (!JavaVersion.current().isJava6Compatible()) {
+        String message = "ERROR: Java 1.6 required but " +
+                         JavaVersion.current() +
                          " found. Change your JAVA_HOME environment variable.";
         throw new IllegalStateException(message);
     }
@@ -96,13 +96,13 @@ findbugsMain {
 }
 
 def sharedManifest = manifest {
-    attributes(['Implementation-Title': project.name, 
+    attributes(['Implementation-Title': project.name,
                 'Implementation-Version': project.version,
                 'Implementation-Vendor': 'ninja-squad.com'])
 }
 
 jar {
-    manifest { 
+    manifest {
         from sharedManifest
         instruction 'Bundle-Vendor', 'ninja-squad.com'
         instructionReplace 'Export-Package',
@@ -137,7 +137,7 @@ javadoc << {
 task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'
     from sourceSets.main.allSource
-    manifest { 
+    manifest {
         from sharedManifest
     }
 }
@@ -145,7 +145,7 @@ task sourcesJar(type: Jar, dependsOn: classes) {
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
     from javadoc.destinationDir
-    manifest { 
+    manifest {
         from sharedManifest
     }
 }
@@ -208,14 +208,14 @@ uploadArchives {
 
 [install.repositories.mavenInstaller, uploadArchives.repositories.mavenDeployer]*.pom*.whenConfigured {pom ->
     // we don't care about test dependencies
-    pom.dependencies = pom.dependencies.findAll {it.scope != 'test'} 
-    // we don't care about findbugs annotations 
-    pom.dependencies = pom.dependencies.findAll {it.groupId != 'net.sourceforge.findbugs' && it.artifactId != 'annotations'} 
+    pom.dependencies = pom.dependencies.findAll {it.scope != 'test'}
+    // we don't care about findbugs annotations
+    pom.dependencies = pom.dependencies.findAll {it.groupId != 'net.sourceforge.findbugs' && it.artifactId != 'annotations'}
     // we don't care about JSR305 annotations
-    pom.dependencies = pom.dependencies.findAll {it.groupId != 'com.google.code.findbugs' && it.artifactId != 'jsr305'} 
+    pom.dependencies = pom.dependencies.findAll {it.groupId != 'com.google.code.findbugs' && it.artifactId != 'jsr305'}
     // all dependencies are compile time dependencies, and there is no need to say it
-    pom.dependencies*.scope = null 
-    
+    pom.dependencies*.scope = null
+
     pom.project {
         name = 'DbSetup'
         description = 'Helps you setup your database with test data'

--- a/src/main/java/com/ninja_squad/dbsetup/destination/ConnectionDestination.java
+++ b/src/main/java/com/ninja_squad/dbsetup/destination/ConnectionDestination.java
@@ -1,0 +1,79 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2012, Ninja Squad
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ninja_squad.dbsetup.destination;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * A destination which wraps a Connection directly.
+ *
+ * It enables the direct usage of connections, e.g. extracted from an JavaEE JPA EntityManager:
+ *
+ * <pre>
+ *    final Destination destination = new ConnectionDestination(em.unwrap(java.sql.Connection.class));
+ * </pre>
+ */
+@Immutable
+public class ConnectionDestination implements Destination {
+
+    private final Connection connection;
+
+    public ConnectionDestination(@Nonnull final Connection connection) {
+        this.connection = connection;
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return connection;
+    }
+
+    @Override
+    public String toString() {
+        return "ConnectionDestination [dataSource=" + connection + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        return connection.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        ConnectionDestination other = (ConnectionDestination) obj;
+        return connection.equals(other.connection);
+    }
+}

--- a/src/test/java/com/ninja_squad/dbsetup/destination/ConnectionDestinationTest.java
+++ b/src/test/java/com/ninja_squad/dbsetup/destination/ConnectionDestinationTest.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2012, Ninja Squad
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.ninja_squad.dbsetup.destination;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import org.junit.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ConnectionDestinationTest {
+
+    @Test
+    public void getConnectionWorks() throws SQLException {
+        Connection connection = mock(Connection.class);
+        assertSame(connection, new ConnectionDestination(connection).getConnection());
+    }
+
+    @Test
+    public void equalsAndHashCodeWork() throws SQLException {
+        Connection connection1 = mock(Connection.class);
+        Destination dest1 = new ConnectionDestination(connection1);
+        Destination dest1bis = new ConnectionDestination(connection1);
+        Connection connection2 = mock(Connection.class);
+        Destination dest2 = new ConnectionDestination(connection2);
+
+        assertEquals(dest1, dest1);
+        assertEquals(dest1, dest1bis);
+        assertEquals(dest1.hashCode(), dest1bis.hashCode());
+        assertFalse(dest1.equals(dest2));
+        assertFalse(dest1.equals(null));
+        assertFalse(dest1.equals("hello"));
+    }
+
+    @Test
+    public void toStringWorks() {
+        Connection connection1 = mock(Connection.class);
+        when(connection1.toString()).thenReturn("connection1");
+        assertEquals("ConnectionDestination [dataSource=connection1]",
+                new ConnectionDestination(connection1).toString());
+    }
+}


### PR DESCRIPTION
Hi team,

I started to explore your tool and considered that it's unnecessarily hard to combine with a JPA `EntityManager` which doesn't expose a DataSource. With the added `ConnectionDestination` it's easier to do that:

```java
final Connection connection = em.unwrap(java.sql.Connection.class);
final ConnectionDestination destination = new ConnectionDestination(connection);
```

Maybe helpful for other users as well?