### PR TITLE
Create Delete operation using an existing Insert operation.

### DIFF
--- a/DbSetup-core/src/main/java/com/ninja_squad/dbsetup/Operations.java
+++ b/DbSetup-core/src/main/java/com/ninja_squad/dbsetup/Operations.java
@@ -29,6 +29,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 
 import com.ninja_squad.dbsetup.operation.CompositeOperation;
+import com.ninja_squad.dbsetup.operation.Delete;
 import com.ninja_squad.dbsetup.operation.DeleteAll;
 import com.ninja_squad.dbsetup.operation.Insert;
 import com.ninja_squad.dbsetup.operation.Operation;
@@ -68,6 +69,18 @@ public final class Operations {
      */
     public static Operation deleteAllFrom(@Nonnull List<String> tables) {
         return DeleteAll.from(tables);
+    }
+
+    /**
+     * Creates a sequence of <code>delete from ... where ...</code> operations.
+     * @param insertOperation the insertOperation used to identify what to delete (table and rows) 
+     * @param pkColumn the name of the column used to match rows to delete (ususally a column with 
+     *          an unicity constraint such as the primary key column) 
+     * @return the created Delete Operation
+     * @see Delete
+     */
+    public static Operation deleteFrom(@Nonnull Insert insertOperation, @Nonnull String pkColumn) {
+        return Delete.from(insertOperation, pkColumn);
     }
 
     /**

--- a/DbSetup-core/src/main/java/com/ninja_squad/dbsetup/operation/Delete.java
+++ b/DbSetup-core/src/main/java/com/ninja_squad/dbsetup/operation/Delete.java
@@ -1,0 +1,164 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2012, Ninja Squad
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ninja_squad.dbsetup.operation;
+
+import com.ninja_squad.dbsetup.bind.BinderConfiguration;
+import com.ninja_squad.dbsetup.util.Preconditions;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.Immutable;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * An operation which deletes every rows from an existing {@link Insert Insert Operation }.
+ * 
+ * <pre>
+ *   Insert insert =
+ *       Insert.into("CLIENT")
+ *             .columns("CLIENT_ID", "FIRST_NAME", "LAST_NAME", "DATE_OF_BIRTH", "CLIENT_TYPE")
+ *             .values(1L, "John", "Doe", "1975-07-19", ClientType.NORMAL)
+ *             .values(2L, "Jack", "Smith", "1969-08-22", ClientType.HIGH_PRIORITY)
+ *             .withDefaultValue("DELETED", false)
+ *             .withDefaultValue("VERSION", 1)
+ *             .withBinder(new ClientTypeBinder(), "CLIENT_TYPE")
+ *             .build();
+ *   Delete d = Delete.from(insert, "CLIENT_ID");
+ * <pre>
+ * 
+ * SQL query: 
+ * <pre>delete from CLIENT where CLIENT_ID in (1L, 2L)</pre>
+ * 
+ * Since the given Insert has already been built, all the rows, even the generated will be correctly deleted.
+ * 
+ * @author R. Flores, E. Kimmel
+ */
+@Immutable
+public final class Delete implements Operation {
+
+    private final Insert insertOperation;
+    
+    private final String pkColumn;
+    
+    private final String sqlQuery;
+
+    private Delete(Insert insertOperation, String pkColumn) {
+        Preconditions.checkNotNull(insertOperation, "insertOperation may not be null");
+        Preconditions.checkNotNull(pkColumn, "pkColumn may not be null");
+        Preconditions.checkArgument(insertOperation.getColumnNames().contains(pkColumn),
+                "insertOperation should contain a column named '" + pkColumn + "'");
+        Preconditions.checkState(insertOperation.getRowCount()>0,
+                "insertOperation should contain at least one row to delete");
+        this.insertOperation = insertOperation;
+        this.pkColumn = pkColumn;
+        this.sqlQuery = generateSqlQuery();
+    }
+
+    @Override
+    public void execute(Connection connection, BinderConfiguration configuration) throws SQLException {
+        Statement stmt = connection.createStatement();
+        try {
+            stmt.executeUpdate(sqlQuery);
+        }
+        finally {
+            stmt.close();
+        }
+    }
+    
+    private String generateSqlQuery() {
+        StringBuilder sql = new StringBuilder("delete from ").append(insertOperation.getTable()).
+                append(" where ").append(pkColumn).append(" in (");
+        List<Object> primaryKeys = extractIdentifiers();
+        for (Iterator<Object> it = primaryKeys.iterator(); it.hasNext(); ) {
+            Object pk = it.next();
+            sql.append(pk);
+            if (it.hasNext()) {
+                sql.append(", ");
+            }
+        }
+        sql.append(')');
+        return sql.toString();
+    }
+
+    private List<Object> extractIdentifiers() {
+        int pkIndex = insertOperation.getColumnNames().indexOf(pkColumn);
+        List<Object> primaryKeys = new ArrayList<Object>();
+        for (List<?> row : insertOperation.getRows()) {
+            Object pk = row.get(pkIndex);
+            primaryKeys.add(pk);
+        }
+        return primaryKeys;
+    }
+
+    /**
+     * Returns an operation which deletes all the rows from the given
+     * insertOperation using the given pkColumn to restrict on tuples.
+     * 
+     * @param insertOperation
+     *            the insertOperation used to identify what to delete (table and
+     *            rows)
+     * @param pkColumn
+     *            the name of the column used to match rows to delete (ususally
+     *            a column with an unicity constraint)
+     * @return the created Delete Operation
+     */
+    public static Delete from(@Nonnull Insert insertOperation, @Nonnull String pkColumn) {
+        return new Delete(insertOperation, pkColumn);
+    }
+
+    @Override
+    public String toString() {
+        return sqlQuery;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + insertOperation.hashCode();
+        result = prime * result + pkColumn.hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Delete other = (Delete) obj;
+        return this.insertOperation.equals(other.insertOperation) && this.pkColumn.equals(other.pkColumn);
+    }
+
+}

--- a/DbSetup-core/src/main/java/com/ninja_squad/dbsetup/operation/Delete.java
+++ b/DbSetup-core/src/main/java/com/ninja_squad/dbsetup/operation/Delete.java
@@ -73,7 +73,7 @@ public final class Delete implements Operation {
         Preconditions.checkNotNull(pkColumn, "pkColumn may not be null");
         Preconditions.checkArgument(insertOperation.getColumnNames().contains(pkColumn),
                 "insertOperation should contain a column named '" + pkColumn + "'");
-        Preconditions.checkState(insertOperation.getRowCount()>0,
+        Preconditions.checkState(insertOperation.getRowCount() > 0,
                 "insertOperation should contain at least one row to delete");
         this.insertOperation = insertOperation;
         this.pkColumn = pkColumn;

--- a/DbSetup-core/src/main/java/com/ninja_squad/dbsetup/operation/Delete.java
+++ b/DbSetup-core/src/main/java/com/ninja_squad/dbsetup/operation/Delete.java
@@ -50,7 +50,7 @@ import java.util.List;
  *             .withBinder(new ClientTypeBinder(), "CLIENT_TYPE")
  *             .build();
  *   Delete d = Delete.from(insert, "CLIENT_ID");
- * <pre>
+ * </pre>
  * 
  * SQL query: 
  * <pre>delete from CLIENT where CLIENT_ID in (1L, 2L)</pre>

--- a/DbSetup-core/src/main/java/com/ninja_squad/dbsetup/operation/Insert.java
+++ b/DbSetup-core/src/main/java/com/ninja_squad/dbsetup/operation/Insert.java
@@ -32,6 +32,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -773,5 +774,16 @@ public final class Insert implements Operation {
         public Builder doTimes(int times) {
             return builder.addRepeatingValues(values, times);
         }
+    }
+
+    protected final String getTable() {
+        return table;
+    }
+    protected final List<String> getColumnNames() {
+        return new ArrayList<String>(columnNames);
+    }
+
+    protected final List<List<?>> getRows() {
+        return Collections.unmodifiableList(rows);
     }
 }

--- a/DbSetup-core/src/main/java/com/ninja_squad/dbsetup/operation/Insert.java
+++ b/DbSetup-core/src/main/java/com/ninja_squad/dbsetup/operation/Insert.java
@@ -776,14 +776,14 @@ public final class Insert implements Operation {
         }
     }
 
-    protected final String getTable() {
+    protected String getTable() {
         return table;
     }
-    protected final List<String> getColumnNames() {
+    protected List<String> getColumnNames() {
         return new ArrayList<String>(columnNames);
     }
 
-    protected final List<List<?>> getRows() {
+    protected List<List<?>> getRows() {
         return Collections.unmodifiableList(rows);
     }
 }

--- a/DbSetup-core/src/test/java/com/ninja_squad/dbsetup/operation/DeleteTest.java
+++ b/DbSetup-core/src/test/java/com/ninja_squad/dbsetup/operation/DeleteTest.java
@@ -1,0 +1,174 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2012, Ninja Squad
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ninja_squad.dbsetup.operation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import org.junit.Test;
+
+import com.ninja_squad.dbsetup.Operations;
+
+/**
+ * @author R. Flores, E. Kimmel
+ */
+public class DeleteTest {
+
+    private final Insert insert= Insert.into("A")
+            .columns("a", "b")
+            .values("a1", "b1")
+            .values("a2", "b2")
+            .row().column("b", "b3")
+                  .column("a", "a3")
+                  .end()
+            .row().column("a", "a4")
+                  .end()
+            .withDefaultValue("c", "c3")
+            .withDefaultValue("d", "d4")
+            .build();
+
+    @Test
+    public void fromWorksWithString() throws IOException {
+        Delete d = Delete.from(insert, "a");
+        assertNotNull(d);
+        String query = d.toString();
+        assertNotNull(query);
+        assertEquals(query,"delete from A where a in (a1, a2, a3, a4)");
+    }
+
+    @Test
+    public void fromWorksWithLong() throws IOException {
+        Insert insert = Insert.into("A")
+                .columns("a", "b")
+                .values(1L, "b1")
+                .values(2L, "b2")
+                .row().column("b", "b3")
+                      .column("a", 3L)
+                      .end()
+                .row().column("a", 4L)
+                      .end()
+                .withDefaultValue("c", "c3")
+                .withDefaultValue("d", "d4")
+                .build();
+        Delete d = Delete.from(insert, "a");
+        assertNotNull(d);
+        String query = d.toString();
+        assertNotNull(query);
+        assertEquals(query,"delete from A where a in (1, 2, 3, 4)");
+    }
+
+    @Test
+    public void fromWorksWithUUID() throws IOException {
+        final UUID UUID1 = UUID.randomUUID();
+        final UUID UUID2 = UUID.randomUUID();
+        final UUID UUID3 = UUID.randomUUID();
+        final UUID UUID4 = UUID.randomUUID();
+        Insert insert = Insert.into("A")
+                .columns("a", "b")
+                .values(UUID1, "b1")
+                .values(UUID2,"b2")
+                .row().column("b", "b3")
+                      .column("a", UUID3)
+                      .end()
+                .row().column("a",UUID4)
+                      .end()
+                .withDefaultValue("c", "c3")
+                .withDefaultValue("d", "d4")
+                .build();
+        Delete d = Delete.from(insert, "a");
+        assertNotNull(d);
+        String query = d.toString();
+        assertNotNull(query);
+        final String actual = "delete from A where a in (" + UUID1 + ", " + UUID2 + ", " + UUID3 + ", " + UUID4 + ")";
+        assertEquals(query, actual);
+    }
+
+    @Test
+    public void fromWorksWithStringifiedUUID() throws IOException {
+        final UUID UUID1 = UUID.randomUUID();
+        final UUID UUID2 = UUID.randomUUID();
+        final UUID UUID3 = UUID.randomUUID();
+        final UUID UUID4 = UUID.randomUUID();
+        Insert insert = Insert.into("A")
+                .columns("a", "b")
+                .values("\""+UUID1.toString()+"\"", "b1")
+                .values("\""+UUID2.toString()+"\"", "b2")
+                .row().column("b", "b3")
+                      .column("a", "\""+UUID3.toString()+"\"")
+                      .end()
+                .row().column("a", "\""+UUID4.toString()+"\"")
+                      .end()
+                .withDefaultValue("c", "c3")
+                .withDefaultValue("d", "d4")
+                .build();
+        Delete d = Delete.from(insert, "a");
+        assertNotNull(d);
+        String query = d.toString();
+        assertNotNull(query);
+        final String actual = "delete from A where a in (\"" + UUID1.toString() + "\", \"" + UUID2.toString() + "\", \""
+                + UUID3.toString() + "\", \"" + UUID4.toString() + "\")";
+        assertEquals(query, actual);
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void fromNullInsert() {
+        Delete.from(null,"");
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void fromNullColumn() {
+        Delete.from(insert,null);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void fromIllegalArgumentMissingColumn() {
+        Delete.from(insert,"unknownColumn");
+    }
+
+    @Test(expected=IllegalStateException.class)
+    public void fromIllegalStateMissingRows() {
+        Delete.from(Insert.into("B").columns("test").build(), "test");
+    }
+
+    @Test
+    public void equalsAndHashCodeWork() {
+        assertEquals(Delete.from(insert, "a"), Operations.deleteFrom(insert, "a"));
+        assertEquals(Delete.from(insert, "a").hashCode(), Delete.from(insert, "a").hashCode());
+        assertFalse(Delete.from(insert, "a").equals(Delete.from(insert,"b")));
+        assertFalse(Delete.from(insert, "a").equals(null));
+        assertFalse(Delete.from(insert, "a").equals("hello"));
+        Delete a = Delete.from(insert, "a");
+        assertEquals(a, a);
+    }
+
+    @Test
+    public void toStringWorks() {
+        assertEquals(Delete.from(insert, "a").toString(), "delete from A where a in (a1, a2, a3, a4)");
+    }
+}


### PR DESCRIPTION
Create an operation which deletes every rows from an existing Insert Operation .

```
   Insert insert =
       Insert.into("CLIENT")
             .columns("CLIENT_ID", "FIRST_NAME", "LAST_NAME", "DATE_OF_BIRTH", "CLIENT_TYPE")
             .values(1L, "John", "Doe", "1975-07-19", ClientType.NORMAL)
             .values(2L, "Jack", "Smith", "1969-08-22", ClientType.HIGH_PRIORITY)
             .withDefaultValue("DELETED", false)
             .withDefaultValue("VERSION", 1)
             .withBinder(new ClientTypeBinder(), "CLIENT_TYPE")
             .build();
   Delete d = Delete.from(insert, "CLIENT_ID");
```
 
Will use following query to delete:
 
`delete from CLIENT where CLIENT_ID in (1L, 2L)`

Since the given Insert has already been built, all the rows, even the generated will be correctly deleted.

The immutable status of `Insert` class is kept for the public API.